### PR TITLE
using promauto for remove init in metrics | fix and activate MailSent…

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -167,15 +167,17 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:d14a5f4bfecf017cb780bdde1b6483e5deb87e12c332544d2c430eda58734bcb"
+  digest = "1:1db19cfa69213ff994b19451023750122862f39643a5f37728126e1b5180eaac"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
+    "prometheus/internal",
+    "prometheus/promauto",
     "prometheus/promhttp",
   ]
   pruneopts = "UT"
-  revision = "c5b7fccd204277076155f10851dad72b76a49317"
-  version = "v0.8.0"
+  revision = "50c4339db732beb2165735d2cde0bff78eb3c5a5"
+  version = "v0.9.3"
 
 [[projects]]
   branch = "master"
@@ -333,6 +335,7 @@
     "github.com/onrik/logrus/filename",
     "github.com/onrik/logrus/sentry",
     "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promauto",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,4 +26,4 @@
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"
-  version = "~0.8.0"
+  version = "~0.9.0"

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -5,28 +5,25 @@ import (
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 )
 
 var (
-	MailReceivedCounter = prometheus.NewCounter(prometheus.CounterOpts{
+	MailReceivedCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "mail_received",
 		Help: "Amount of mails receiveds",
 	})
-	MailSentCounter = prometheus.NewCounter(prometheus.CounterOpts{
+	MailSentCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "mail_sent",
 		Help: "Amount of mails sents",
 	})
-	WrongProjectCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "Wrong project",
+	WrongProjectCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "wrong_project",
 		Help: "Project that doesn't exist",
 	})
 )
-
-func init() {
-	prometheus.MustRegister(MailReceivedCounter)
-}
 
 func ListenAndServe(listen string) error {
 	http.Handle("/metrics", promhttp.Handler())


### PR DESCRIPTION
Replace init() function for metrics with promauto. Fix and activate MailSentCounter and WrongProjectCounter metrics